### PR TITLE
Mention the usage of submodules in forge

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ workflows.
 Forge is using submodules to manage dependencies. Initialize the dependencies:
 
 ```bash
-git submodule update --init
+forge install
 ```
 
 If you are in the root directory of the project, run:

--- a/README.md
+++ b/README.md
@@ -35,6 +35,12 @@ workflows.
 
 ### Solidity
 
+Forge is using submodules to manage dependencies. Initialize the dependencies:
+
+```bash
+git submodule update --init
+```
+
 If you are in the root directory of the project, run:
 
 ```bash


### PR DESCRIPTION
I got below when trying to test this repo. 
Without knowing how forge manages dependencies users might get stuck. This PR reduces friction.

Thanks for coming up with this template! Just sad I did not find it sooner :')

```bash
$ forge build --root ./contracts
compiling...
Unable to resolve imported file: "ds-test/test.sol"
Compiling 2 files with 0.8.10
Compilation finished successfully
Error: 
   0: Compiler run failed
      ParserError: Source "ds-test/test.sol" not found: File not found.
       --> /tmp/foundry-rust-template/contracts/src/test/Contract.t.sol:4:1:
        |
      4 | import "ds-test/test.sol";
        | 
```
