### PR TITLE
chore(doc): Fix README Instructions for Forge Install in Root Directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,19 @@ workflows.
 
 Forge is using submodules to manage dependencies. Initialize the dependencies:
 
+If you are in the root directory of the project, run:
+
+```bash
+forge install --root ./contracts
+```
+
+If you are in in `contracts/`:
+
 ```bash
 forge install
 ```
+
+Then, run the tests:
 
 If you are in the root directory of the project, run:
 


### PR DESCRIPTION
## Overview
This PR updates the README to correct the instructions for running `forge install` from the root directory. This change resolves an error that occurred due to the absence of the `lib` directory when running the command from the root.
