### PR TITLE
feat: add template for smart contract deployment and interaction

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,4 +2,4 @@
 members = ["app", "crates/bindings"]
 
 [workspace.dependencies]
-foundry-contracts = { path = "crates/bindings" }
+bindings = { path = "crates/bindings" }

--- a/app/Cargo.toml
+++ b/app/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-foundry-contracts.workspace = true
+bindings.workspace = true
 eyre = "0.6"
 tokio = { version = "1.19", features = ["macros", "rt-multi-thread"] }
 alloy = { git = "https://github.com/alloy-rs/alloy", features = [

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -3,7 +3,7 @@ use alloy::{
     providers::{builder, Provider},
 };
 use eyre::Result;
-use foundry_contracts::counter::Counter;
+use bindings::counter::Counter;
 
 #[tokio::main]
 async fn main() -> Result<()> {

--- a/app/src/main.rs
+++ b/app/src/main.rs
@@ -1,6 +1,6 @@
 use alloy::{
-    primitives::Address,
-    providers::{builder, Provider},
+    primitives::U256,
+    providers::builder,
 };
 use eyre::Result;
 use bindings::counter::Counter;
@@ -9,11 +9,23 @@ use bindings::counter::Counter;
 async fn main() -> Result<()> {
     let provider = builder().with_recommended_fillers().on_anvil_with_wallet();
 
-    let address = "0x0000000000000000000000000000000000000000".parse::<Address>()?;
+    let deployed_contract = Counter::deploy(provider.clone()).await?;
+    println!("Deployed contract at address: {:?}", deployed_contract.address());
 
-    let _contract = Counter::new(address, provider.clone());
+    let initial_number = deployed_contract.number().call().await?;
+    println!("Initial number: {}", initial_number._0);
 
-    let blk = provider.get_block_number().await?;
-    println!("Hello, world! {}", blk);
+    let new_number = U256::from(123);
+    let set_number_tx = deployed_contract.setNumber(new_number).send().await?;
+    println!("setNumber called, transaction hash: {:?}", set_number_tx.tx_hash());
+
+    let updated_number = deployed_contract.number().call().await?;
+    println!("Updated number after setting: {}", updated_number._0);
+
+    let increment_tx = deployed_contract.increment().send().await?;
+    println!("increment called, transaction hash: {:?}", increment_tx.tx_hash());
+
+    let incremented_number = deployed_contract.number().call().await?;
+    println!("Number after incrementing: {}", incremented_number._0);
     Ok(())
 }

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "foundry-contracts"
+name = "bindings"
 version = "0.1.0"
 edition = "2021"
 


### PR DESCRIPTION
This PR standardizes the crate name for generated contract bindings to `bindings`. Previously, building the project could produce a different crate name, forcing changes in workspace dependencies and imports. Now, using `bindings` ensures stable references (e.g., `use bindings::...`) and prevents the need to update workspace configurations after each build.